### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Directions:
 3. Open up Nodejs console ```node```
 4. Compile the contract
   ```
+  Web3 = require('web3')
+  web3 = new Web3(new Web3.providers.HttpsProvider("http://localhost:8545"));
   code = fs.readFileSync('Voting.sol').toString()
   solc = require('solc')
   compiledCode = solc.compile(code)


### PR DESCRIPTION
The added commands are necessary in order to include Web3. Without them, web3 not found error occurs.